### PR TITLE
Check for pthread_setname_np() correctly.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,4 +23,7 @@ AC_TYPE_SIZE_T
 # Checks for library functions.
 AC_CHECK_FUNCS([memset mkdir realpath strdup])
 
+# Check for unportable pthread_setname_np()
+AC_CHECK_LIB(pthread, pthread_setname_np)
+
 AC_OUTPUT(Makefile src/Makefile scripts/Makefile)

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -512,7 +512,7 @@ btfs_init(struct fuse_conn_info *conn) {
 	pthread_create(&alert_thread, NULL, alert_queue_loop,
 		new Log(p->save_path + "/../log.txt"));
 
-#ifndef __APPLE__
+#ifdef HAVE_PTHREAD_SETNAME_NP
 	pthread_setname_np(alert_thread, "alert");
 #endif
 


### PR DESCRIPTION
Do not blindly assume that it's available in all OSes but Apple.
Not all C libraries implement this because it's a non POSIX extension.

Fixes compilation with the musl C library.