### PR TITLE
Setting file/directory's mtime to the moment of retrieving its metadata

### DIFF
--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -400,6 +400,7 @@ btfs_getattr(const char *path, struct stat *stbuf) {
 		stbuf->st_mode = S_IFREG | 0444;
 		stbuf->st_size = file.size;
 	}
+	stbuf->st_mtime = time(NULL);
 
 	pthread_mutex_unlock(&lock);
 


### PR DESCRIPTION
Hi, Just thought it'd be great to see some actual date, not the epoch beginning.