### PR TITLE
Added comparison against nullptr

### DIFF
--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -788,21 +788,22 @@ populate_target(std::string& target, char *arg) {
 	templ += "/btfs-XXXXXX";
 
 	char *s = strdup(templ.c_str());
+	if (s != NULL) {
+		if (mkdtemp(s) != NULL) {
+			char *x = realpath(s, NULL);
 
-	if (mkdtemp(s) != NULL) {
-		char *x = realpath(s, NULL);
+			if (x)
+				target = x;
+			else
+				perror("Failed to expand target");
 
-		if (x)
-			target = x;
-		else
-			perror("Failed to expand target");
+			free(x);		
+		} else {
+			perror("Failed to generate target");
+		}
 
-		free(x);		
-	} else {
-		perror("Failed to generate target");
+		free(s);
 	}
-
-	free(s);
 
 	return target.length() > 0;
 }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Warning, found using PVS-Studio:
btfs/src/btfs.cc    792     warn    V575 The potential null pointer is passed into 'mkdtemp' function. Inspect the first argument.