### PR TITLE
Add --notcp flag to disable TCP.

### DIFF
--- a/man/btfs.1
+++ b/man/btfs.1
@@ -25,7 +25,7 @@ download metadata only
 \fB\-k\fR   \fB\-\-keep\fR
 keep files after unmount
 .TP
-\fB\-\-notcp\fR
+\fB\-\-utp\-only\fR
 do not use TCP
 .TP
 \fB\-\-data-directory=\fIDIRECTORY\fR

--- a/man/btfs.1
+++ b/man/btfs.1
@@ -25,6 +25,9 @@ download metadata only
 \fB\-k\fR   \fB\-\-keep\fR
 keep files after unmount
 .TP
+\fB\-\-notcp\fR
+do not use TCP
+.TP
 \fB\-\-data-directory=\fIDIRECTORY\fR
 directory in which to put btfs download data. default is $HOME/btfs, or /tmp/btfs if unavailable
 .TP

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -604,8 +604,8 @@ btfs_init(struct fuse_conn_info *conn) {
 	se.strict_end_game_mode = false;
 	se.announce_to_all_trackers = true;
 	se.announce_to_all_tiers = true;
-	se.enable_incoming_tcp = !params.notcp;
-	se.enable_outgoing_tcp = !params.notcp;
+	se.enable_incoming_tcp = !params.utp_only;
+	se.enable_outgoing_tcp = !params.utp_only;
 	se.download_rate_limit = params.max_download_rate * 1024;
 	se.upload_rate_limit = params.max_upload_rate * 1024;
 
@@ -645,8 +645,8 @@ btfs_init(struct fuse_conn_info *conn) {
 	pack.set_bool(pack.strict_end_game_mode, false);
 	pack.set_bool(pack.announce_to_all_trackers, true);
 	pack.set_bool(pack.announce_to_all_tiers, true);
-	pack.set_bool(pack.enable_incoming_tcp, !params.notcp);
-	pack.set_bool(pack.enable_outgoing_tcp, !params.notcp);
+	pack.set_bool(pack.enable_incoming_tcp, !params.utp_only);
+	pack.set_bool(pack.enable_outgoing_tcp, !params.utp_only);
 	pack.set_int(pack.download_rate_limit, params.max_download_rate * 1024);
 	pack.set_int(pack.upload_rate_limit, params.max_upload_rate * 1024);
 	pack.set_int(pack.alert_mask, alerts);
@@ -924,7 +924,7 @@ static const struct fuse_opt btfs_opts[] = {
 	BTFS_OPT("--browse-only",                browse_only,          1),
 	BTFS_OPT("-k",                           keep,                 1),
 	BTFS_OPT("--keep",                       keep,                 1),
-	BTFS_OPT("--notcp",                      notcp,                1),
+	BTFS_OPT("--utp-only",                   utp_only,             1),
 	BTFS_OPT("--data-directory=%s",          data_directory,       4),
 	BTFS_OPT("--min-port=%lu",               min_port,             4),
 	BTFS_OPT("--max-port=%lu",               max_port,             4),
@@ -961,7 +961,7 @@ print_help() {
 	printf("    --help-fuse            print all fuse options\n");
 	printf("    --browse-only -b       download metadata only\n");
 	printf("    --keep -k              keep files after unmount\n");
-	printf("    --notcp                do not use TCP\n");
+	printf("    --utp-only             do not use TCP\n");
 	printf("    --data-directory=dir   directory in which to put btfs data\n");
 	printf("    --min-port=N           start of listen port range\n");
 	printf("    --max-port=N           end of listen port range\n");

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -604,6 +604,8 @@ btfs_init(struct fuse_conn_info *conn) {
 	se.strict_end_game_mode = false;
 	se.announce_to_all_trackers = true;
 	se.announce_to_all_tiers = true;
+	se.enable_incoming_tcp = !params.notcp;
+	se.enable_outgoing_tcp = !params.notcp;
 	se.download_rate_limit = params.max_download_rate * 1024;
 	se.upload_rate_limit = params.max_upload_rate * 1024;
 
@@ -643,6 +645,8 @@ btfs_init(struct fuse_conn_info *conn) {
 	pack.set_bool(pack.strict_end_game_mode, false);
 	pack.set_bool(pack.announce_to_all_trackers, true);
 	pack.set_bool(pack.announce_to_all_tiers, true);
+	pack.set_bool(pack.enable_incoming_tcp, !params.notcp);
+	pack.set_bool(pack.enable_outgoing_tcp, !params.notcp);
 	pack.set_int(pack.download_rate_limit, params.max_download_rate * 1024);
 	pack.set_int(pack.upload_rate_limit, params.max_upload_rate * 1024);
 	pack.set_int(pack.alert_mask, alerts);
@@ -920,6 +924,7 @@ static const struct fuse_opt btfs_opts[] = {
 	BTFS_OPT("--browse-only",                browse_only,          1),
 	BTFS_OPT("-k",                           keep,                 1),
 	BTFS_OPT("--keep",                       keep,                 1),
+	BTFS_OPT("--notcp",                      notcp,                1),
 	BTFS_OPT("--data-directory=%s",          data_directory,       4),
 	BTFS_OPT("--min-port=%lu",               min_port,             4),
 	BTFS_OPT("--max-port=%lu",               max_port,             4),
@@ -956,6 +961,7 @@ print_help() {
 	printf("    --help-fuse            print all fuse options\n");
 	printf("    --browse-only -b       download metadata only\n");
 	printf("    --keep -k              keep files after unmount\n");
+	printf("    --notcp                do not use TCP\n");
 	printf("    --data-directory=dir   directory in which to put btfs data\n");
 	printf("    --min-port=N           start of listen port range\n");
 	printf("    --max-port=N           end of listen port range\n");

--- a/src/btfs.h
+++ b/src/btfs.h
@@ -123,6 +123,7 @@ struct btfs_params {
 	int help_fuse;
 	int browse_only;
 	int keep;
+	int notcp;
 	char *data_directory;
 	int min_port;
 	int max_port;

--- a/src/btfs.h
+++ b/src/btfs.h
@@ -123,7 +123,7 @@ struct btfs_params {
 	int help_fuse;
 	int browse_only;
 	int keep;
-	int notcp;
+	int utp_only;
 	char *data_directory;
 	int min_port;
 	int max_port;


### PR DESCRIPTION
Started using btfs and found it very useful. Thanks for sharing!
To decrease load on my home router, I prefer﻿ to use only UDP.
Adding a `--notcp` flag to make it explicit, even if libtorrent looks quite smart in trying to use UDP as much as possible. Newbie libtorrent user, I guess this way it will ensure UDP/uTP only. Feedback appreciated.
Could not come up with a convenient short switch, especially in advance of a possible `--noudp` switch in the future.
Also, I've used Docker for my hacking workflow. I will submit a PR soon, if interested.
