### PR TITLE
Add Docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM gcc
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y \
+      fuse \
+      libfuse-dev \
+      libtorrent-rasterbar-dev \
+      libcurl4-openssl-dev \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY . /src/btfs/
+WORKDIR /src/btfs/
+
+RUN \
+  autoreconf -fvi && \
+  ./configure
+
+RUN \
+  make && \
+  make install
+
+ENTRYPOINT [ "btfs", "-f" ]

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ Use [`brew`](https://brew.sh) to get the dependencies.
 And optionally, if you want to install it:
 
     $ make install
+
+## Building and running with Docker
+Both `Dockerfile` and Docker Compose [manifest](./docker-compose.yml) are provided. They can be used both for deploying and for development (no need to install development toolchain in your machine, just Docker and Docker Compose).
+You can use them to build and run from source a container which will mount [Sintel]() movie torrent in your `/tmp/btfs-docker/` dir by doing:
+```
+$ docker-compose up --build --force-recreate
+```
+Stop it by `CTRL+C`'ing or by executing `docker stop btfs` from another shell.
+
+See the `docker-compose.yml` manifest file for more info and customizations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "2.4"
+services:
+  btfs:
+    container_name: btfs
+    restart: unless-stopped
+    build: .
+    command:
+      - "-o"
+      - "allow_other"
+      - "--utp-only"
+      - "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel"
+      - "/mnt"
+    cap_add:
+      - ALL
+      - SYS_ADMIN
+    devices:
+      - /dev/fuse
+    privileged: true
+    security_opt:
+      - apparmor:unconfined
+    volumes:
+      - /tmp/btfs-docker/:/mnt/:shared


### PR DESCRIPTION
This PR includes:
﻿- Dockerfile initial version.
- Docker Compose manifest.
- Documentation update on using them.

The former is used to build the code and create a Docker image. The latter contains the configuration (exposing FUSE from Docker is a bit tricky) to run a container from the previously built image which will mount Sintel on `/tmp/`, as described in docs. Just do `docker-compose up` as stated in docs.

Using both files enabled me to develop and test #69 without needing to install any development libs or tools in my machine.

Optionally, the `Dockerfile` can also be used to create a public Docker image built from source to use as a distribution method via [Automated Builds](https://docs.docker.com/docker-hub/builds/) on Docker Hub. It takes just a few minutes of clicking to register and link the AB to GitHub's repo. Currently, I'm using one based off my fork successfully. I think it makes for an easy way to let people download the latest version easily.
