### PR TITLE
use XDG_DATA_HOME if defined

### DIFF
--- a/man/btfs.1
+++ b/man/btfs.1
@@ -29,7 +29,7 @@ keep files after unmount
 do not use TCP
 .TP
 \fB\-\-data-directory=\fIDIRECTORY\fR
-directory in which to put btfs download data. default is $HOME/btfs, or /tmp/btfs if unavailable
+directory in which to put btfs download data. will by default use $XDG_DATA_HOME if defined else use $HOME/btfs, or /tmp/btfs if the latter is unavailable
 .TP
 \fB\-\-min-port=\fIPORT\fR
 start of listen port range

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -772,6 +772,9 @@ populate_target(std::string& target, char *arg) {
 
 	if (arg) {
 		templ += arg;
+	} else if (getenv("XDG_DATA_HOME")) {
+		templ += getenv("XDG_DATA_HOME");
+		templ += "/btfs";
 	} else if (getenv("HOME")) {
 		templ += getenv("HOME");
 		templ += "/btfs";


### PR DESCRIPTION
Would be nice to be using XDG_DATA_HOME by default if the env is defined. Unclutter the home dir a little bit. 
It will still use $HOME/btfs or /tmp/btfs if XDG_DATA_HOME is not defined. 