### PR TITLE
Add command-line option to disable logs (closes #48)

### DIFF
--- a/man/btfs.1
+++ b/man/btfs.1
@@ -25,6 +25,9 @@ download metadata only
 \fB\-k\fR   \fB\-\-keep\fR
 keep files after unmount
 .TP
+\fB\-s\fR   \fB\-\-silent\fR
+do not create logs
+.TP
 \fB\-\-utp\-only\fR
 do not use TCP
 .TP

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -663,7 +663,7 @@ btfs_init(struct fuse_conn_info *conn) {
 #endif
 
 	pthread_create(&alert_thread, NULL, alert_queue_loop,
-		new Log(p->save_path + "/../log.txt"));
+               new Log(params.silent ? std::string() : (p->save_path + "/../log.txt")));
 
 #ifdef HAVE_PTHREAD_SETNAME_NP
 	pthread_setname_np(alert_thread, "alert");
@@ -927,6 +927,8 @@ static const struct fuse_opt btfs_opts[] = {
 	BTFS_OPT("--browse-only",                browse_only,          1),
 	BTFS_OPT("-k",                           keep,                 1),
 	BTFS_OPT("--keep",                       keep,                 1),
+	BTFS_OPT("-s",                           silent,               1),
+	BTFS_OPT("--silent",                     silent,               1),
 	BTFS_OPT("--utp-only",                   utp_only,             1),
 	BTFS_OPT("--data-directory=%s",          data_directory,       4),
 	BTFS_OPT("--min-port=%lu",               min_port,             4),
@@ -964,6 +966,7 @@ print_help() {
 	printf("    --help-fuse            print all fuse options\n");
 	printf("    --browse-only -b       download metadata only\n");
 	printf("    --keep -k              keep files after unmount\n");
+	printf("    --silent -s            do not create logs\n");
 	printf("    --utp-only             do not use TCP\n");
 	printf("    --data-directory=dir   directory in which to put btfs data\n");
 	printf("    --min-port=N           start of listen port range\n");
@@ -991,6 +994,9 @@ main(int argc, char *argv[]) {
 
 	if (fuse_opt_parse(&args, &params, btfs_opts, btfs_process_arg))
 		RETV(fprintf(stderr, "Failed to parse options\n"), -1);
+
+        if (params.silent)
+                printf("No logs.\n");
 
 	if (!params.metadata)
 		params.help = 1;

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -663,7 +663,7 @@ btfs_init(struct fuse_conn_info *conn) {
 #endif
 
 	pthread_create(&alert_thread, NULL, alert_queue_loop,
-               new Log(params.silent ? std::string() : (p->save_path + "/../log.txt")));
+		new Log(params.silent ? std::string() : (p->save_path + "/../log.txt")));
 
 #ifdef HAVE_PTHREAD_SETNAME_NP
 	pthread_setname_np(alert_thread, "alert");
@@ -994,9 +994,6 @@ main(int argc, char *argv[]) {
 
 	if (fuse_opt_parse(&args, &params, btfs_opts, btfs_process_arg))
 		RETV(fprintf(stderr, "Failed to parse options\n"), -1);
-
-        if (params.silent)
-                printf("No logs.\n");
 
 	if (!params.metadata)
 		params.help = 1;

--- a/src/btfs.h
+++ b/src/btfs.h
@@ -100,7 +100,7 @@ public:
 class Log : public std::ofstream
 {
 public:
-       Log(std::string p) : std::ofstream(p.empty() ? "/dev/null" : p.c_str()), path(p) {
+	Log(std::string p) : std::ofstream(p.empty() ? "/dev/null" : p.c_str()), path(p) {
 		if (!is_open())
 			// If open log file fails, write to a dummy file
 			open("/dev/null");

--- a/src/btfs.h
+++ b/src/btfs.h
@@ -100,7 +100,7 @@ public:
 class Log : public std::ofstream
 {
 public:
-	Log(std::string p) : std::ofstream(p.c_str()), path(p) {
+       Log(std::string p) : std::ofstream(p.empty() ? "/dev/null" : p.c_str()), path(p) {
 		if (!is_open())
 			// If open log file fails, write to a dummy file
 			open("/dev/null");
@@ -109,7 +109,7 @@ public:
 	~Log() {
 		close();
 
-		if (remove(path.c_str()))
+		if (!path.empty() && remove(path.c_str()))
 			perror("Failed to remove log");
 	}
 
@@ -123,6 +123,7 @@ struct btfs_params {
 	int help_fuse;
 	int browse_only;
 	int keep;
+	int silent;
 	int utp_only;
 	char *data_directory;
 	int min_port;


### PR DESCRIPTION
Set the logger to `/dev/null` when run with `-s` or `--silent`.