### PR TITLE
Add --no-prefetch flag to disable downloading the whole torrent

### DIFF
--- a/man/btfs.1
+++ b/man/btfs.1
@@ -45,6 +45,9 @@ maximum download rate (in kilobytes per second)
 .TP
 \fB\-\-max-upload-rate=\fIRATE\fR
 maximum upload rate (in kilobytes per second)
+.TP
+\fB\-\-no\-prefetch\fR
+do not download files unless an application requests it
 .SH EXAMPLES
 mounting a torrent file:
   btfs video.torrent ~/mnt

--- a/src/btfs.cc
+++ b/src/btfs.cc
@@ -106,7 +106,9 @@ jump(int piece, int size) {
 
 static void
 advance() {
-	jump(cursor, 0);
+	if(!params.no_prefetch) {
+		jump(cursor, 0);
+	}
 }
 
 Read::Read(char *buf, int index, off_t offset, size_t size) {
@@ -117,6 +119,10 @@ Read::Read(char *buf, int index, off_t offset, size_t size) {
 #else
 	int64_t file_size = ti->files().file_size(index);
 #endif
+
+	if(params.no_prefetch) {
+		handle.file_priority(index, 1);
+	}
 
 	while (size > 0 && offset < file_size) {
 		libtorrent::peer_request part = ti->map_file(index, offset,
@@ -182,8 +188,15 @@ int Read::read() {
 	// Trigger reads of finished pieces
 	trigger();
 
-	// Move sliding window to first piece to serve this request
-	jump(parts.front().part.piece, size());
+	if (params.no_prefetch) {
+		// Set priority of needed pieces
+		for (parts_iter i = parts.begin(); i != parts.end(); ++i) {
+			handle.piece_priority(i->part.piece, 7);
+		}
+	} else {
+		// Move sliding window to first piece to serve this request
+		jump(parts.front().part.piece, size());
+	}
 
 	while (!finished() && !failed)
 		// Wait for any piece to downloaded
@@ -206,6 +219,9 @@ setup() {
 
 	for (int i = 0; i < ti->num_files(); ++i) {
 		std::string parent("");
+		if(params.no_prefetch) {
+			handle.file_priority(i, 0);
+		}
 
 #if LIBTORRENT_VERSION_NUM < 10100
 		char *p = strdup(ti->file_at(i).path.c_str());
@@ -935,6 +951,7 @@ static const struct fuse_opt btfs_opts[] = {
 	BTFS_OPT("--max-port=%lu",               max_port,             4),
 	BTFS_OPT("--max-download-rate=%lu",      max_download_rate,    4),
 	BTFS_OPT("--max-upload-rate=%lu",        max_upload_rate,      4),
+	BTFS_OPT("--no-prefetch",                no_prefetch,          1),
 	FUSE_OPT_END
 };
 
@@ -973,6 +990,7 @@ print_help() {
 	printf("    --max-port=N           end of listen port range\n");
 	printf("    --max-download-rate=N  max download rate (in kB/s)\n");
 	printf("    --max-upload-rate=N    max upload rate (in kB/s)\n");
+	printf("    --no-prefetch          don't prefetch files in the background\n");
 }
 
 int

--- a/src/btfs.h
+++ b/src/btfs.h
@@ -131,6 +131,7 @@ struct btfs_params {
 	int max_download_rate;
 	int max_upload_rate;
 	const char *metadata;
+	int no_prefetch;
 };
 
 }


### PR DESCRIPTION
I've been playing with making peer-to-peer software repositories for DNF/RPM. This tool is very useful since I can create a torrent of my repository and mount it to make the repo accessible to the package manager.

I noticed in #72 that btfs by design downloads the whole torrent. In my use case, I only want the files that the package manager needs to read to be downloaded from the torrent, and it seems from that issue that other users may have similar use cases.

In this pull request I have added the `--no-prefetch` flag which when used changes the behaviour of btfs in the following ways:

1. Sets all files to priority 0 in the `setup()` function.
2. Sets a file to priority 1 when read.
3. Sets the pieces that are requested in the read to priority 7

This means that once a file is partly read, pieces of that file only will be downloaded in the background, but the priority will still be on the parts of the file the application requested from the filesystem.

Thank you for your time and consideration.