### PR TITLE
fuse3: port btfs to libfuse 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         apt-get update
-        apt-get -y install build-essential g++ autoconf autoconf-archive automake libtool libtorrent-rasterbar-dev libfuse-dev libcurl4-openssl-dev
+        apt-get -y install build-essential g++ autoconf autoconf-archive automake libtool libtorrent-rasterbar-dev libfuse3-dev libcurl4-openssl-dev
     - name: Build
       run: |
         autoreconf -i

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Use [`brew`](https://brew.sh) to install on macOS.
 
 ## Dependencies (on Linux)
 
-* fuse ("fuse" in Ubuntu 16.04)
-* libtorrent ("libtorrent-rasterbar8" in Ubuntu 16.04)
-* libcurl ("libcurl3" in Ubuntu 16.04)
+* fuse3 ("fuse3" in Ubuntu 22.04)
+* libtorrent ("libtorrent-rasterbar8" in Ubuntu 22.04)
+* libcurl ("libcurl4" in Ubuntu 22.04)
 
 ## Building from git on a recent Debian/Ubuntu
 
-    $ sudo apt-get install autoconf automake libfuse-dev libtorrent-rasterbar-dev libcurl4-openssl-dev g++
+    $ sudo apt-get install autoconf automake libfuse3-dev libtorrent-rasterbar-dev libcurl4-openssl-dev g++
     $ git clone https://github.com/johang/btfs.git btfs
     $ cd btfs
     $ autoreconf -i
@@ -68,7 +68,7 @@ And optionally, if you want to install it:
 
 Use [`brew`](https://brew.sh) to get the dependencies.
 
-    $ brew install Caskroom/cask/osxfuse libtorrent-rasterbar autoconf automake pkg-config
+    $ brew install --cask macfuse libtorrent-rasterbar autoconf automake pkg-config
     $ git clone https://github.com/johang/btfs.git btfs
     $ cd btfs
     $ autoreconf -i

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT(btfs, 2.24, johan.gunnarsson@gmail.com, btfs, https://github.com/johang/btfs)
+AC_INIT([btfs],[2.24],[johan.gunnarsson@gmail.com],[btfs],[https://github.com/johang/btfs])
 AC_CONFIG_SRCDIR([src/btfs.cc])
 
 AM_INIT_AUTOMAKE
@@ -8,7 +8,7 @@ AM_INIT_AUTOMAKE
 AC_PROG_CXX
 
 # Checks for libraries.
-PKG_CHECK_MODULES(FUSE, fuse >= 2.8.0)
+PKG_CHECK_MODULES(FUSE, fuse3 >= 3.0)
 PKG_CHECK_MODULES(LIBTORRENT, libtorrent-rasterbar >= 1.0.0)
 PKG_CHECK_MODULES(LIBCURL, libcurl >= 7.22.0)
 
@@ -25,4 +25,5 @@ AC_CHECK_LIB(pthread, pthread_setname_np)
 # Check if -latomic is needed.
 AC_SEARCH_LIBS(__atomic_load, atomic)
 
-AC_OUTPUT(Makefile src/Makefile scripts/Makefile man/Makefile)
+AC_CONFIG_FILES([Makefile src/Makefile scripts/Makefile man/Makefile])
+AC_OUTPUT


### PR DESCRIPTION
- configure.ac: detect fuse3 ≥ 3.0
- btfs.cc: set FUSE_USE_VERSION 31, update callback signatures, use fuse_main_real()
- docs/CI: switch packages to libfuse3-dev (Linux, macOS)

Fixes #92