### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: btfs CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'master' ]


### PR DESCRIPTION
Potential fix for [https://github.com/johang/btfs/security/code-scanning/1](https://github.com/johang/btfs/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is the minimum required for the workflow to function correctly. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
